### PR TITLE
Changed link for modules

### DIFF
--- a/Interim/README.md
+++ b/Interim/README.md
@@ -10,7 +10,7 @@ To use interim release:
 1. Download ansible.tar.gz and easy_install
 2. Run on terminal:
 - chmod +x easy_install
-- ./easy_instal
+- ./easy_install
 Above commands will detect where Ansible is installed, overwrite modified files and add new icx_modules.
 
 # Bug Jiras:Modules

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Ansible-Release
 Ansible releases with ICX modules
-https://docs.ansible.com/ansible/latest/modules/list_of_network_modules.html#icx
+https://docs.ansible.com/ansible/latest/collections/index_module.html


### PR DESCRIPTION
Link was dead since Ansible now lists modules under collections.